### PR TITLE
MessageStore fixed. Permanently delete logs option added.

### DIFF
--- a/components/LogsModal.tsx
+++ b/components/LogsModal.tsx
@@ -17,6 +17,7 @@
 */
 
 import { classNameFactory } from "@api/Styles";
+import { openUserProfile } from "@utils/discord";
 import { copyWithToast } from "@utils/misc";
 import { closeAllModals, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import { LazyComponent, useAwaiter } from "@utils/react";
@@ -369,6 +370,15 @@ function LMessage({ log, isGroupStart, forceUpdate, }: LMessageProps) {
                                 closeAllModals();
                             }}
                         />
+                        <Menu.MenuItem
+                            key="open-user-profile"
+                            id="open-user-profile"
+                            label="Open user profile"
+                            action={() => {
+                                closeAllModals();
+                                openUserProfile(message.author.id);
+                            }}
+                        />
 
                         <Menu.MenuItem
                             key="copy-content"
@@ -415,7 +425,12 @@ function LMessage({ log, isGroupStart, forceUpdate, }: LMessageProps) {
                             id="delete-log"
                             label="Delete Log"
                             color="danger"
-                            action={() => removeLog(log.message.id).then(() => forceUpdate())}
+                            action={() =>
+                                removeLog(log.message.id)
+                                    .then(() => {
+                                        forceUpdate();
+                                    })
+                            }
                         />
 
                     </Menu.Menu>

--- a/index.tsx
+++ b/index.tsx
@@ -59,7 +59,9 @@ const cacheThing = findByPropsLazy("commit", "getOrCreate");
 const handledMessageIds = new Set();
 async function messageDeleteHandler(payload: MessageDeletePayload & { isBulk: boolean; }) {
     if (payload.mlDeleted) {
-        if (payload.id === "ml-remove-history" && settings.store.permanentlyRemoveLogByDefault) removeLog(payload.id);
+        if (settings.store.permanentlyRemoveLogByDefault)
+            await removeLog(payload.id);
+
         return;
     }
 
@@ -324,6 +326,12 @@ export const settings = definePluginSettings({
         default: false,
         type: OptionType.BOOLEAN,
         description: "When enabled, a context menu button will be added to messages to allow you to delete messages without them being logged by other loggers. Might not be safe, use at your own risk."
+    },
+
+    hideMessageFromMessageLoggersDeletedMessage: {
+        default: "redacted eh",
+        type: OptionType.STRING,
+        description: "The message content to replace the message with when using the hide message from message loggers feature.",
     },
 
     messageLimit: {
@@ -749,7 +757,7 @@ const contextMenuPath: NavContextMenuPatchCallback = (children, props) => {
                                 action={async () => {
                                     await MessageActions.deleteMessage(props.message.channel_id, props.message.id);
                                     MessageActions._sendMessage(props.message.channel_id, {
-                                        "content": "redacted eh",
+                                        "content": settings.store.hideMessageFromMessageLoggersDeletedMessage,
                                         "tts": false,
                                         "invalidEmojis": [],
                                         "validNonShortcutEmojis": []

--- a/utils/misc.ts
+++ b/utils/misc.ts
@@ -19,10 +19,10 @@
 import { get, set } from "@api/DataStore";
 import { PluginNative } from "@utils/types";
 import { findByPropsLazy, findLazy } from "@webpack";
-import { ChannelStore, UserStore } from "@webpack/common";
+import { ChannelStore, moment, UserStore } from "@webpack/common";
 
 import { LOGGED_MESSAGES_KEY, MessageLoggerStore } from "../LoggedMessageManager";
-import { LoggedMessage, LoggedMessageJSON } from "../types";
+import { LoggedMessageJSON } from "../types";
 import { DEFAULT_IMAGE_CACHE_DIR } from "./constants";
 import { DISCORD_EPOCH } from "./index";
 import { memoize } from "./memoize";
@@ -91,7 +91,7 @@ export const messageJsonToMessageClass = memoize((log: { message: LoggedMessageJ
     // console.time("message populate");
     if (!log?.message) return null;
 
-    const message: LoggedMessage = new MessageClass(log.message);
+    const message: any = new MessageClass(log.message);
     // @ts-ignore
     message.timestamp = getTimestamp(message.timestamp);
 
@@ -100,11 +100,15 @@ export const messageJsonToMessageClass = memoize((log: { message: LoggedMessageJ
         message.editHistory = editHistory;
     }
     if (message.editedTimestamp)
-        message.editedTimestamp = getTimestamp(message.editedTimestamp) as any;
+        message.editedTimestamp = getTimestamp(message.editedTimestamp);
     message.author = new AuthorClass(message.author);
-    (message.author as any).nick = (message.author as any).globalName ?? message.author.username;
+    message.author.nick = message.author.globalName ?? message.author.username;
 
     message.embeds = message.embeds.map(e => embedModule.sanitizeEmbed(message.channel_id, message.id, e));
+
+    if (message.poll)
+        message.poll.expiry = moment(message.poll.expiry);
+
     // console.timeEnd("message populate");
     return message;
 });


### PR DESCRIPTION
- MessageStore patch find changed to '"MessageStrore"'. Now loading logs properly.
- Added Open user profile option to logged message context menu
![image](https://github.com/Syncxv/vc-message-logger-enhanced/assets/62884000/405429ff-1e5a-4dad-8d19-6caba0cf0592)
- Option to permanently delete logs via base MessageLogger remove button (default: false) strictly checks for ML dispatch to avoid looping (ik that it never happens but just in case)
![image](https://github.com/Syncxv/vc-message-logger-enhanced/assets/62884000/c1029325-5552-4f3f-9a53-934ef30ac107) 
