### PR TITLE
Fix popout window message colour

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,11 @@
     padding: 1rem 2rem;
 }
 
+/* Edited message content highlighting */
+div[class*="messagelogger-edited"] {
+    color: var(--channel-text-area-placeholder) !important;
+}
+
 /*
  Originally part of
  https://github.com/Vendicated/Vencord/blob/main/src/plugins/messageLogger/deleteStyleText.css


### PR DESCRIPTION
### Description of Changes

Sets Messge Logger Enhanced's popout window for displaying deleted (text) messages the same colour as regular text message within Discord's chat buffer. This mimics mlv2's behaviour.
### Rationale behind Changes

Vencord's [Message Logger] hardcodes deleted messages element as warning text, which is red. This colouring can make it unsuitable when:
* User's themes are dark theme (e.g. dark theme),
* Viewing large amounts of deleted messages, especially through Message Logger Enhanced's popout window

By redefining deleted messages colour for Message Logger Enhanced's popout window to dynamic variants e.g. `color: var(--text-normal)`, it can potentially help with legibility. This change also make Message Logger Enhanced's popout window be a bit more similar to mlv2 when it comes to deleted text messages.
### Suggested Testing Steps

* By using Vencord's QuickCSS, add the following:
```css
/* Message content highlighting */
div[class*="messagelogger-deleted"] [class*="contents"] > :is(div, h1, h2, h3, p) {
    color: var(--text-normal) !important;
}

/* Markdown title highlighting */
div[class*="messagelogger-deleted"] [class*="contents"] :is(h1, h2, h3) {
    color: var(--text-normal) !important;
}

/* Bot "thinking" text highlighting */
div[class*="messagelogger-deleted"] [class*="colorStandard"] {
    color: var(--text-normal) !important;
}

/* Embed highlighting */
div[class*="messagelogger-deleted"] article :is(div, span, h1, h2, h3, p) {
    color: var(--text-normal) !important;
}

div[class*="messagelogger-deleted"] a {
    color: var(--text-link) !important;
    text-decoration: underline;
}
```
* Open Message Logger Enhanced's popout window,
* Changes should be visible.

[Message Logger]: https://github.com/Vendicated/Vencord/blob/main/src/plugins/messageLogger/deleteStyleText.css