### PR TITLE
Fix typo in settings.tsx 'Wether' to 'Whether'

### DIFF
--- a/settings.tsx
+++ b/settings.tsx
@@ -30,7 +30,7 @@ export const settings = definePluginSettings({
     saveMessages: {
         default: true,
         type: OptionType.BOOLEAN,
-        description: "Wether to save the deleted and edited messages.",
+        description: "Whether to save the deleted and edited messages.",
     },
 
     saveImages: {


### PR DESCRIPTION
From this snippet of code:

```
export const settings = definePluginSettings({
    checkForUpdate: {
        type: OptionType.COMPONENT,
        description: "Check for update",
        component: () =>
            <Button onClick={() => openUpdaterModal()}>
                Check For Updates
            </Button>
    },
    saveMessages: {
        default: true,
        type: OptionType.BOOLEAN,
        description: "Wether to save the deleted and edited messages.",
    },

    saveImages: {
        type: OptionType.BOOLEAN,
        description: "Save deleted attachments.",
        default: false
    },
```

change the "saveMessages" description from "Wether to save ..." to "Whether to save ...".