### PR TITLE
fix broken import

### DIFF
--- a/components/LogsModal.tsx
+++ b/components/LogsModal.tsx
@@ -7,8 +7,7 @@
 import { classNameFactory } from "@api/Styles";
 import { Flex } from "@components/Flex";
 import { InfoIcon } from "@components/Icons";
-import { openUserProfile } from "@utils/discord";
-import { copyWithToast } from "@utils/misc";
+import { openUserProfile, copyWithToast } from "@utils/discord";
 import { closeAllModals, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import { LazyComponent } from "@utils/react";
 import { find, findByCode, findByCodeLazy } from "@webpack";

--- a/components/settings/FolderSelectInput.tsx
+++ b/components/settings/FolderSelectInput.tsx
@@ -17,7 +17,7 @@
 */
 
 import { classNameFactory } from "@api/Styles";
-import { copyWithToast } from "@utils/misc";
+import { copyWithToast } from "@utils/discord";
 import { Button, Forms, Toasts } from "@webpack/common";
 
 import { Native, settings } from "../..";


### PR DESCRIPTION
`import { copyWithToast } from "@utils/misc";` does not exists anymore
I changed it to `import { copyWithToast } from "@utils/discord";`