### PR TITLE
fix: prevent message limit cleanup storms

### DIFF
--- a/LoggedMessageManager.ts
+++ b/LoggedMessageManager.ts
@@ -17,10 +17,24 @@
 */
 
 import { Flogger, settings } from ".";
-import { addMessageIDB, db, DBMessageStatus, deleteMessagesBulkIDB, getOldestMessagesIDB } from "./db";
+import { addMessageIDB, db, DBMessageStatus, deleteMessagesBulkIDB, getOldestMessageIdsIDB } from "./db";
+import { createMessageLimitEnforcer, getMessageLimitDeleteCount } from "./messageLimitEnforcer";
 import { LoggedMessage, LoggedMessageJSON } from "./types";
 import { cleanupMessage } from "./utils";
 import { cacheMessageImages } from "./utils/saveImage";
+
+const enforceMessageLimit = createMessageLimitEnforcer(async () => {
+    if (settings.store.messageLimit > 0) {
+        const currentMessageCount = await db.count("messages");
+        const messagesToDelete = getMessageLimitDeleteCount(currentMessageCount, settings.store.messageLimit);
+        if (messagesToDelete > 0) {
+            const oldestMessageIds = await getOldestMessageIdsIDB(messagesToDelete);
+
+            Flogger.info(`Deleting ${oldestMessageIds.length} oldest messages`);
+            await deleteMessagesBulkIDB(oldestMessageIds);
+        }
+    }
+});
 
 export const addMessage = async (message: LoggedMessage | LoggedMessageJSON, status: DBMessageStatus) => {
     if (settings.store.saveImages && status === DBMessageStatus.DELETED)
@@ -28,17 +42,5 @@ export const addMessage = async (message: LoggedMessage | LoggedMessageJSON, sta
     const finalMessage = cleanupMessage(message);
 
     await addMessageIDB(finalMessage, status);
-
-    if (settings.store.messageLimit > 0) {
-        const currentMessageCount = await db.count("messages");
-        if (currentMessageCount > settings.store.messageLimit) {
-            const messagesToDelete = currentMessageCount - settings.store.messageLimit;
-            if (messagesToDelete <= 0 || messagesToDelete >= settings.store.messageLimit) return;
-
-            const oldestMessages = await getOldestMessagesIDB(messagesToDelete);
-
-            Flogger.info(`Deleting ${messagesToDelete} oldest messages`);
-            await deleteMessagesBulkIDB(oldestMessages.map(m => m.message_id));
-        }
-    }
+    await enforceMessageLimit();
 };

--- a/db.ts
+++ b/db.ts
@@ -104,8 +104,19 @@ export async function getMessagesByStatusIDB(status: DBMessageStatus) {
     return cacheRecords(await db.getAllFromIndex("messages", "by_status", status));
 }
 
-export async function getOldestMessagesIDB(limit: number) {
-    return cacheRecords(await db.getAllFromIndex("messages", "by_timestamp", undefined, limit));
+export async function getOldestMessageIdsIDB(limit: number) {
+    const tx = db.transaction("messages", "readonly");
+    const index = tx.store.index("by_timestamp");
+    const messageIds: string[] = [];
+    let cursor = await index.openKeyCursor();
+
+    while (cursor && messageIds.length < limit) {
+        messageIds.push(String(cursor.primaryKey));
+        cursor = await cursor.continue();
+    }
+
+    await tx.done;
+    return messageIds;
 }
 
 export async function* iterateAllMessagesIDB(batchSize = 100) {

--- a/messageLimitEnforcer.test.mjs
+++ b/messageLimitEnforcer.test.mjs
@@ -1,0 +1,65 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMessageLimitEnforcer, getMessageLimitDeleteCount } from "./messageLimitEnforcer.ts";
+
+test("coalesces concurrent requests and reruns after writes during cleanup", async () => {
+    let runs = 0;
+    let release;
+    const blocked = new Promise(resolve => { release = resolve; });
+    const enforce = createMessageLimitEnforcer(async () => {
+        runs++;
+        if (runs === 1)
+            await blocked;
+    });
+
+    const requests = Array.from({ length: 100 }, () => enforce());
+    assert.equal(runs, 1);
+    assert.ok(requests.every(request => request === requests[0]));
+    release();
+    await Promise.all(requests);
+    assert.equal(runs, 2);
+
+    await enforce();
+    assert.equal(runs, 3);
+});
+
+test("allows retry after failed enforcement", async () => {
+    let runs = 0;
+    const enforce = createMessageLimitEnforcer(async () => {
+        runs++;
+        if (runs === 1)
+            throw new Error("failed cleanup");
+    });
+
+    await assert.rejects(enforce(), /failed cleanup/);
+    await enforce();
+    assert.equal(runs, 2);
+});
+
+test("trims below the hard limit to avoid deleting on every write", () => {
+    assert.equal(getMessageLimitDeleteCount(50000, 50000), 0);
+    assert.equal(getMessageLimitDeleteCount(50001, 50000), 501);
+    assert.equal(getMessageLimitDeleteCount(49500, 50000), 0);
+    assert.equal(getMessageLimitDeleteCount(101, 100), 2);
+    assert.equal(getMessageLimitDeleteCount(5001, 5000), 51);
+    assert.equal(getMessageLimitDeleteCount(1000001, 1000000), 1001);
+});

--- a/messageLimitEnforcer.ts
+++ b/messageLimitEnforcer.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export function createMessageLimitEnforcer(enforce: () => Promise<void>) {
+    let pending: Promise<void> | null = null;
+    let rerun = false;
+
+    return function enforceMessageLimit() {
+        if (pending != null) {
+            rerun = true;
+            return pending;
+        }
+
+        pending = (async () => {
+            do {
+                rerun = false;
+                await enforce();
+            } while (rerun);
+        })().finally(() => {
+            pending = null;
+            rerun = false;
+        });
+        return pending;
+    };
+}
+
+export function getMessageLimitDeleteCount(currentCount: number, messageLimit: number) {
+    if (messageLimit <= 0 || currentCount <= messageLimit)
+        return 0;
+
+    const headroom = Math.min(1000, Math.max(1, Math.floor(messageLimit / 100)));
+    return currentCount - Math.max(0, messageLimit - headroom);
+}


### PR DESCRIPTION
## Summary

Reaching the saved-message limit could make Discord's renderer repeatedly scan and delete IndexedDB records. Concurrent message arrivals could start many cleanups for the same over-limit snapshot, while steady traffic at the hard limit triggered another deletion on every saved message.

This change coalesces concurrent cleanup requests, reruns once when writes arrive during cleanup, and trims 1% below the configured limit (capped at 1,000 messages) to avoid immediate cleanup churn. Cleanup now reads only the oldest primary keys instead of loading full message records and attachment blobs into memory.

| Scenario | Before | After |
|---|---:|---:|
| 100 concurrent writes at a 50,000-message limit | 100 cleanup runs; 10,000 full records selected | 1 active cleanup plus 1 rerun |
| 500 sequential writes at the hard limit | 500 delete cycles | 1 delete cycle per 500-message headroom window |

## Testing

- Added deterministic Node tests for concurrent coalescing/rerun behavior, failure recovery, and low-watermark boundaries: 3/3 passing.
- Reproduced the current algorithm with synchronized write/count/select barriers before applying the fix.
- Ran ESLint for all modified TypeScript files in a fresh Vencord checkout.
- Ran `pnpm buildStandalone` successfully with the plugin embedded in current Vencord `master`.
- Current Vencord `testTsc` reports 17 pre-existing plugin compatibility errors; the exact error set is identical before and after this change.
